### PR TITLE
Upgrade Slack GitHub Action to version 3.0.1

### DIFF
--- a/.github/workflows/ucvm-ci.yml
+++ b/.github/workflows/ucvm-ci.yml
@@ -35,7 +35,7 @@ jobs:
       shell: bash
     - name: Notify Slack on failure
       if: ${{ failure() }}
-      uses: slackapi/slack-github-action@v2
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK }}
         webhook-type: incoming-webhook
@@ -71,7 +71,7 @@ jobs:
       shell: bash
     - name: Notify Slack on failure
       if: ${{ failure() }}
-      uses: slackapi/slack-github-action@v2
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK }}
         webhook-type: incoming-webhook
@@ -105,7 +105,7 @@ jobs:
       shell: bash
     - name: Notify Slack on failure
       if: ${{ failure() }}
-      uses: slackapi/slack-github-action@v2
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK }}
         webhook-type: incoming-webhook


### PR DESCRIPTION
Updating to the latest version (v3.0.1) of [Slack GitHub Action](https://github.com/marketplace/actions/the-slack-github-action).

This is necessary as the previous version (v2) used Node 20, which is going EOL this April. Updating to v3 which uses Node 24 ensures the actions continue to work.